### PR TITLE
fix: remove proofStatePool.ClearPrev() from GatherOtherPeerSignature()

### DIFF
--- a/miner/signatureProcess.go
+++ b/miner/signatureProcess.go
@@ -37,7 +37,7 @@ func (c *Certify) GatherOtherPeerSignature(validator common.Address, height *big
 
 	//log.Info("Certify.GatherOtherPeerSignature", "c.miner.GetWorker().chain.CurrentHeader().Number", c.miner.GetWorker().chain.CurrentHeader().Number,
 	//	"height", height, "c.proofStatePool.proofs[height] == nil 1", c.proofStatePool.proofs[height.Uint64()] == nil)
-	c.proofStatePool.ClearPrev(c.miner.GetWorker().chain.CurrentHeader().Number)
+	//c.proofStatePool.ClearPrev(c.miner.GetWorker().chain.CurrentHeader().Number)
 	//log.Info("Certify.GatherOtherPeerSignature", "c.miner.GetWorker().chain.CurrentHeader().Number", c.miner.GetWorker().chain.CurrentHeader().Number,
 	//	"height", height, "c.proofStatePool.proofs[height] == nil 2", c.proofStatePool.proofs[height.Uint64()] == nil)
 	averageCoefficient, err := c.miner.GetWorker().GetAverageCoefficient() // need to divide 10

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -564,6 +564,7 @@ func (w *worker) emptyLoop() {
 						//sgiccommon.Sigc <- syscall.SIGTERM
 					}
 				}
+				w.cerytify.proofStatePool.ClearPrev(w.chain.CurrentHeader().Number)
 			}
 		}
 	}


### PR DESCRIPTION
remove proofStatePool.ClearPrev() from GatherOtherPeerSignature() and add it to emptyLoop()